### PR TITLE
Add support for controller names without either .directive or .controller in the file name

### DIFF
--- a/Rosieks.VisualStudio.Angular/Commands/GoToCodeCmd.cs
+++ b/Rosieks.VisualStudio.Angular/Commands/GoToCodeCmd.cs
@@ -1,4 +1,6 @@
-﻿namespace Rosieks.VisualStudio.Angular.Commands
+﻿using System.Collections.Generic;
+
+namespace Rosieks.VisualStudio.Angular.Commands
 {
     using System;
     using System.ComponentModel.Design;
@@ -92,9 +94,13 @@
         private string GetCodePath(string path)
         {
             var fileName = Path.GetFileNameWithoutExtension(path);
-            fileName = fileName.Contains(".directive.") ? fileName : fileName + ".controller";
-            string codePath = Path.Combine(Path.GetDirectoryName(path), fileName);
-            if (FileHelper.TryFind(codePath, AngularPackage.CodeExtensions, out codePath))
+            var searchPaths = new List<string>();
+
+            var adjustedFileName = fileName.Contains(".directive.") ? fileName : fileName + ".controller";
+            searchPaths.Add(Path.Combine(Path.GetDirectoryName(path), fileName));
+
+            string codePath;
+            if (FileHelper.TryFind(searchPaths.ToArray(), AngularPackage.CodeExtensions, out codePath))
             {
                 return codePath;
             }

--- a/Rosieks.VisualStudio.Angular/Commands/GoToCodeCmd.cs
+++ b/Rosieks.VisualStudio.Angular/Commands/GoToCodeCmd.cs
@@ -97,6 +97,7 @@ namespace Rosieks.VisualStudio.Angular.Commands
             var searchPaths = new List<string>();
 
             var adjustedFileName = fileName.Contains(".directive.") ? fileName : fileName + ".controller";
+            searchPaths.Add(Path.Combine(Path.GetDirectoryName(path), adjustedFileName));
             searchPaths.Add(Path.Combine(Path.GetDirectoryName(path), fileName));
 
             string codePath;

--- a/Rosieks.VisualStudio.Angular/Commands/GoToCodeCmd.cs
+++ b/Rosieks.VisualStudio.Angular/Commands/GoToCodeCmd.cs
@@ -1,12 +1,11 @@
-﻿using System.Collections.Generic;
-
-namespace Rosieks.VisualStudio.Angular.Commands
+﻿namespace Rosieks.VisualStudio.Angular.Commands
 {
     using System;
     using System.ComponentModel.Design;
     using System.IO;
     using System.Linq;
     using System.Runtime.InteropServices;
+    using System.Collections.Generic;
     using EnvDTE;
     using Microsoft.VisualStudio.Shell;
     using Microsoft.VisualStudio.Shell.Interop;
@@ -96,6 +95,7 @@ namespace Rosieks.VisualStudio.Angular.Commands
             var fileName = Path.GetFileNameWithoutExtension(path);
             var searchPaths = new List<string>();
 
+            // SEACH FOR THE FOLLOWING FILES {viewName}.directive.js, {viewName}.controller.js, {viewName}.js
             var adjustedFileName = fileName.Contains(".directive.") ? fileName : fileName + ".controller";
             searchPaths.Add(Path.Combine(Path.GetDirectoryName(path), adjustedFileName));
             searchPaths.Add(Path.Combine(Path.GetDirectoryName(path), fileName));

--- a/Rosieks.VisualStudio.Angular/Commands/GoToViewCmd.cs
+++ b/Rosieks.VisualStudio.Angular/Commands/GoToViewCmd.cs
@@ -76,7 +76,7 @@
                 hierarchy.GetProperty(projectItemId, (int)__VSHPROPID.VSHPROPID_ExtSelectedItem, out value);
                 string path;
                 hierarchy.GetCanonicalName(projectItemId, out path);
-                string viewPath = this.GetViewPath(path); path.Replace("controller.", "").Replace(".js", ".html").Replace(".ts", ".html");
+                string viewPath = this.GetViewPath(path); //path.Replace("controller.", "").Replace(".js", ".html").Replace(".ts", ".html");
                 if (File.Exists(viewPath))
                 {
                     this.dte.OpenFileInPreviewTab(viewPath);

--- a/Rosieks.VisualStudio.Angular/Extensions/FileHelper.cs
+++ b/Rosieks.VisualStudio.Angular/Extensions/FileHelper.cs
@@ -3,9 +3,12 @@
     using System.IO;
     internal class FileHelper
     {
-        internal static bool TryFind(string[] paths, string[] extensions, out string fileName) {
-            foreach (var path in paths) {
-                if (TryFind(path, extensions, out fileName)) {
+        internal static bool TryFind(string[] paths, string[] extensions, out string fileName)
+        {
+            foreach (var path in paths)
+            {
+                if (TryFind(path, extensions, out fileName))
+                {
                     return true;
                 };
             }

--- a/Rosieks.VisualStudio.Angular/Extensions/FileHelper.cs
+++ b/Rosieks.VisualStudio.Angular/Extensions/FileHelper.cs
@@ -3,6 +3,17 @@
     using System.IO;
     internal class FileHelper
     {
+        internal static bool TryFind(string[] paths, string[] extensions, out string fileName) {
+            foreach (var path in paths) {
+                if (TryFind(path, extensions, out fileName)) {
+                    return true;
+                };
+            }
+
+            fileName = null;
+            return false;
+        }
+
         internal static bool TryFind(string path, string[] extensions, out string fileName)
         {
             foreach (var extension in extensions)


### PR DESCRIPTION
Added support for finding the code file when files are named as:

View: {viewName}.cshtml
Controller: {viewName}.js